### PR TITLE
Add simple polish improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A short, atmospheric storybook game about squirrels, storms, and strange friends
 
 🌀 A tornado threatens Saint Brunswick.  
 🌰 A woman who feeds squirrels must decide who she wants to save.  
-🎙️ Narrated with a soothing British voice.  
+🎙️ Narrated with a soothing British voice.
 🖼️ Accompanied by painterly, AI-generated visuals.
+✨ Smooth fade transitions and keyboard controls for a more polished feel.
 
 ## 🎮 Play It Now
 👉 [Live on GitHub Pages](https://shadohead55.github.io/Squirrels-in-Paradise/)

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       margin: 0;
       background-color: black;
       color: white;
-      font-family: Arial, sans-serif;
+      font-family: 'Georgia', serif;
       display: flex;
       justify-content: center;
       align-items: center;
@@ -25,6 +25,8 @@
       z-index: 1;
       word-wrap: break-word;
       line-height: 1.5;
+      background: rgba(0, 0, 0, 0.5);
+      border-radius: 8px;
     }
     #bg-image {
       position: absolute;
@@ -36,6 +38,13 @@
       filter: brightness(1);
       z-index: 0;
       display: none;
+    }
+    .fade-in {
+      animation: fadeIn 1s forwards;
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
     }
   </style>
 </head>
@@ -61,6 +70,12 @@
     const storyBox = document.getElementById("story-box");
     const bgImage = document.getElementById("bg-image");
 
+    function fadeIn(el) {
+      el.classList.remove('fade-in');
+      void el.offsetWidth;
+      el.classList.add('fade-in');
+    }
+
     function nextSlide() {
       if (index < slides.length) {
         const line = slides[index];
@@ -80,6 +95,9 @@
 
         if (index >= 0 && index <= 9) bgImage.style.display = 'block';
         else bgImage.style.display = 'none';
+
+        fadeIn(storyBox);
+        fadeIn(bgImage);
 
         index++;
       }
@@ -124,6 +142,12 @@
 
     waitForVoices(() => {
       advanceStory();
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === ' ' || e.key === 'ArrowRight') {
+        advanceStory();
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- enhance the story page visuals with a serif font, a semi-transparent box and fade animation
- add fade-in helper and animate each slide
- allow advancing the story with spacebar/right arrow
- note the improvements in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684e6b37b50483238b672fed2d77d165